### PR TITLE
Place Photo request moved to server side

### DIFF
--- a/src/api/place.js
+++ b/src/api/place.js
@@ -13,9 +13,10 @@ export const getPlaces = (city, callback) => {
 export const getPhoto = (ref, callback) => {
   fetch(`${API_URL}/place/photo?photo_ref=${ref}`)
     .then((response) => {
-      if (response.ok) return response.json();
+      if (response.ok) {
+        return callback(response.url);
+      }
       return console.log("Error");
     })
-    .then((data) => callback(data))
     .catch((err) => console.log(err));
 };

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,6 +1,7 @@
 import React, { memo, useMemo, useCallback, useState, useEffect } from "react";
 import { GoogleMap, useJsApiLoader, Marker, InfoWindow } from "@react-google-maps/api";
 import { websiteIcon, addressIcon } from "../assets/icons";
+import { getPhoto } from "../api/place";
 import styled from "styled-components";
 import { base } from "../themes";
 
@@ -127,8 +128,9 @@ const StyledDetails = styled.div`
 `;
 
 const InfoWindowDetails = ({ name, website, url, description, photoRef }) => {
-  const API_KEY = process.env.REACT_APP_GOOGLE_PLACES_API_KEY;
-  const image = `https://maps.googleapis.com/maps/api/place/photo?photo_reference=${photoRef}&maxwidth=400&key=${API_KEY}`;
+  const [image, setImage] = useState(null);
+
+  useEffect(() => getPhoto(photoRef, (image) => setImage(image)), [photoRef]);
 
   return (
     <StyledDetails>

--- a/src/components/PlaceCard.js
+++ b/src/components/PlaceCard.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef } from "react";
-// import { getPhoto } from "../api/place";
+import React, { useEffect, useRef, useState } from "react";
+import { getPhoto } from "../api/place";
 import { addressIcon, websiteIcon } from "../assets/icons";
 import styled from "styled-components";
 
@@ -49,13 +49,11 @@ const Grid = styled.div(
 );
 
 const PlaceCard = ({ place, activeMarker, setActiveMarker }) => {
-  const photoRef = place.photos[0].photo_reference;
-  const API_KEY = process.env.REACT_APP_GOOGLE_PLACES_API_KEY;
-  const image = `https://maps.googleapis.com/maps/api/place/photo?photo_reference=${photoRef}&maxwidth=400&key=${API_KEY}`;
+  const [image, setImage] = useState(null);
 
-  // SERVER-SIDE CALL, NOT WORKING
-  // const [image, setImage] = useState(null);
-  // useEffect(() => getPhoto(photoRef, (image) => setImage(image)), [photoRef]);
+  const photoRef = place.photos[0].photo_reference;
+
+  useEffect(() => getPhoto(photoRef, (image) => setImage(image)), [photoRef]);
 
   const isActiveMarker = place.place_id === activeMarker;
   const placeRef = useRef(null);


### PR DESCRIPTION
Previously the request to Google's Places API was done on the client-side, contradicting best practices and exposing the Places API key. An endpoint was created to then move the request to the server side. 